### PR TITLE
Respect CXX variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Create an optimized build:
 #   CXXFLAGS="-O3 -flto -DNDEBUG" make
 
-CXX          = g++-4.7
+CXX         ?= g++-4.7
 LINK.o       = $(LINK.cc)
 PREFIX      ?= /usr/local
 TARGET_ARCH ?= -march=native


### PR DESCRIPTION
Don't override 'CXX' in the Makefile, making it buildable on systems like Arch Linux which doesn't have 'g++-4.7'.
