### PR TITLE
Alias the `sig_t` type to `sighandler_t` on Macs

### DIFF
--- a/artiste.cc
+++ b/artiste.cc
@@ -14,6 +14,10 @@
 
 #include "movie.h"
 
+#ifdef __APPLE__
+using sighandler_t = sig_t;
+#endif
+
 using std::cout;
 using std::string;
 


### PR DESCRIPTION
… apparently the Apple/BSD `signal.h` interface is exactly the same as what’s on Linux, except for this. The codebase as it stands, on master at HEAD, errors out during `make` like so:

    asio-otus:hiptext[master]$ make
    c++ -g -O3 -std=c++11 -Wall -Wextra -fno-exceptions -fno-rtti -MD  -march=native -c -o hiptext.o hiptext.cc
    c++ -g -O3 -std=c++11 -Wall -Wextra -fno-exceptions -fno-rtti -MD  -march=native -c -o artiste.o artiste.cc
    artiste.cc:165:3: error: unknown type name 'sighandler_t'
      sighandler_t old_handler = signal(SIGINT, OnCtrlC);
      ^
    1 error generated.
    make: *** [artiste.o] Error 1


… but if I include the one alias per the PR, `hiptext` builds OK (with both Apple Clang 6.2 something and also LLVM Clang, somewhat recent HEAD from the  3.7 branch) and but then everything runs completely as advertised in every way thereafter:

![screen shot 2015-08-08 at 12 19 33 pm](https://cloud.githubusercontent.com/assets/378969/9151188/dce93112-3dc7-11e5-9733-364fbdf7bb05.jpg)


Yes!