### PR TITLE
Ffmpeg improvements

### DIFF
--- a/hiptext.cc
+++ b/hiptext.cc
@@ -250,12 +250,13 @@ int main(int argc, char** argv) {
   }
   string path = argv[1];
   string extension = GetExtension(path);
+  string uri_sig = "://"; // Given this string signature, assume that it's a video stream
   if (extension == "png") {
     artiste.PrintImage(LoadPNG(path));
   } else if (extension == "jpg" || extension == "jpeg") {
     artiste.PrintImage(LoadJPEG(path));
   } else if (extension == "mov" || extension == "mp4" || extension == "flv" ||
-             extension == "avi" || extension == "mkv") {
+             extension == "avi" || extension == "mkv" || path.find(uri_sig) != string::npos) {
     artiste.PrintMovie(Movie(path));
   } else {
     fprintf(stderr, "Unknown Filetype: %s\n", extension.data());

--- a/movie.cc
+++ b/movie.cc
@@ -53,7 +53,7 @@ void Movie::PrepareRGB(int width, int height) {
 
   // Prepare context for scaling and converting to RGB.
   sws_ = sws_getContext(context_->width, context_->height, context_->pix_fmt,
-                        width_, height_, PIX_FMT_RGB24, SWS_FAST_BILINEAR,
+                        width_, height_, AV_PIX_FMT_RGB24, SWS_FAST_BILINEAR,
                         nullptr, nullptr, nullptr);
   CHECK(codec_ = avcodec_find_decoder(context_->codec_id))
       << "Unsupported codec.\n";
@@ -61,13 +61,13 @@ void Movie::PrepareRGB(int width, int height) {
       << "Could not open codec.\n";
 
   // Allocate Raw + RGB frame buffers.
-  CHECK(frame_ = avcodec_alloc_frame());
-  CHECK(frame_rgb_ = avcodec_alloc_frame());
-  int rgb_bytes = avpicture_get_size(PIX_FMT_RGB24, width_, height_);
+  CHECK(frame_ = av_frame_alloc());
+  CHECK(frame_rgb_ = av_frame_alloc());
+  int rgb_bytes = avpicture_get_size(AV_PIX_FMT_RGB24, width_, height_);
   buffer_ = static_cast<uint8_t*>(av_malloc(rgb_bytes));
   LOG(INFO) << "RGB Buffer: " << rgb_bytes << " bytes.";
   int prep = avpicture_fill(reinterpret_cast<AVPicture*>(frame_rgb_),
-                            buffer_, PIX_FMT_RGB24, width_, height_);
+                            buffer_, AV_PIX_FMT_RGB24, width_, height_);
   CHECK_GE(prep, 0) << "Failed to prepare RGB buffer.";
   LOG(INFO) << "RGB dimensions: " << width_  << "x" << height_;
 }


### PR DESCRIPTION
I've been playing with using hipitext to output video streams. First I needed to change some symbols to compile against newer versions of ffmpeg, namely v3.0.1. Then I also needed to add some crude substr detection for URIs rather than just file extensions.

BTW, hiptext is waaaaaaaaay better than mplayer's libcaca etc.

The compiler still throws some warnings about deprecated symbols. Can/should the `Makefile` pin to a specific version of `ffmpeg`?

Oh yes! Almost forgot. I first came across hiptext through rickrollrc! Happy days 😊