### PR TITLE
Fix typos

### DIFF
--- a/graphic.cc
+++ b/graphic.cc
@@ -55,7 +55,7 @@ Graphic& Graphic::Equalize() {
     return std::min(255, std::max(0, static_cast<int>(v * kBins)));
   };
 
-  // Count the occurence of each color into bins.
+  // Count the occurrence of each color into bins.
   for (int y = 0; y < height_; ++y) {
     for (int x = 0; x < width_; ++x) {
       const Pixel& pixel = Get(x, y);

--- a/macterm.cc
+++ b/macterm.cc
@@ -99,7 +99,7 @@ MactermColor::MactermColor(const Pixel& top, const Pixel& bot) {
 // Terminal.app on Mac OS X is interesting. First of all, it doesn't follow the
 // xterm-256color standard, but that's probably for the best since xterm's
 // palette was obviously chosen by engineers rather than designers. The problem
-// is I'm not quite sure what Terminal.app is doing. It slightly ajusts the
+// is I'm not quite sure what Terminal.app is doing. It slightly adjusts the
 // color when displaying foregrounds and backgrounds but I'm not sure what
 // formula they're using to do it. They also seem to slightly alter colors
 // depending on the terminal theme. The following colors are what I scraped

--- a/pixel.cc
+++ b/pixel.cc
@@ -166,7 +166,7 @@ Pixel& Pixel::Mix(const Pixel& other) {
 
 // http://www.springerreference.com/docs/html/chapterdbid/212829.html
 static double A(double c) {
-  // This is K/S part of the the equations on that website.
+  // This is K/S part of the equations on that website.
   // a = (1 - c)^2 / (2c)
   return std::pow(1.0 - c, 2.0) / (2.0 * max(c, 1e-6));
 }

--- a/xterm256.cc
+++ b/xterm256.cc
@@ -6,7 +6,7 @@
 #include <glog/logging.h>
 #include "pixel.h"
 
-DEFINE_bool(fast, false, "Use O(1) xterm256 aproximate color quantizer.");
+DEFINE_bool(fast, false, "Use O(1) xterm256 approximate color quantizer.");
 
 static const uint8_t g_cube_steps[] = {0, 95, 135, 175, 215, 255};
 


### PR DESCRIPTION
These misspellings were found using [mwic](http://jwilk.net/software/mwic).