### PR TITLE
Screencast desktop

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ libhiptext_a_SOURCES = \
 	src/hiptext/jpeg.h \
 	src/hiptext/macterm.h \
 	src/hiptext/movie.h \
+	src/hiptext/x11.h \
+	src/hiptext/input.h \
 	src/hiptext/pixel.h \
 	src/hiptext/png.h \
 	src/hiptext/sixelprinter.h \
@@ -42,6 +44,8 @@ libhiptext_a_SOURCES = \
 	src/jpeg.cc \
 	src/macterm.cc \
 	src/movie.cc \
+	src/x11.cc \
+	src/input.cc \
 	src/pixel.cc \
 	src/pixel_parse.cc \
 	src/pixel_parse.rl \
@@ -72,6 +76,7 @@ hiptext_CPPFLAGS = $(libhiptext_a_CPPFLAGS)
 hiptext_LDADD = \
 	libhiptext.a \
 	-ljpeg \
+	-lX11 \
 	$(LIBAVCODEC_LIBS) \
 	$(LIBAVFORMAT_LIBS) \
 	$(LIBAVUTIL_LIBS) \

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,8 @@ AC_CHECK_LIB(jpeg, jpeg_set_defaults, [], [
   AC_MSG_ERROR([error: libjpeg is required])
 ])
 
+AC_PATH_XTRA
+
 PKG_CHECK_MODULES(LIBAVCODEC, libavcodec)
 PKG_CHECK_MODULES(LIBAVFORMAT, libavformat)
 PKG_CHECK_MODULES(LIBAVUTIL, libavutil)

--- a/src/hiptext.cc
+++ b/src/hiptext.cc
@@ -257,12 +257,13 @@ int main(int argc, char** argv) {
   }
   string path = argv[1];
   string extension = GetExtension(path);
+  string uri_sig = "://"; // Given this string signature, assume that it's a video stream
   if (extension == "png") {
     artiste.PrintImage(LoadPNG(path));
   } else if (extension == "jpg" || extension == "jpeg") {
     artiste.PrintImage(LoadJPEG(path));
   } else if (extension == "mov" || extension == "mp4" || extension == "flv" ||
-             extension == "avi" || extension == "mkv") {
+             extension == "avi" || extension == "mkv" || path.find(uri_sig) != string::npos) {
     artiste.PrintMovie(Movie(path));
   } else {
     fprintf(stderr, "Unknown Filetype: %s\n", extension.data());

--- a/src/hiptext.cc
+++ b/src/hiptext.cc
@@ -70,7 +70,8 @@ void PrintImageSixel256(std::ostream& os, const Graphic& graphic) {
       int code = to_index(graphic.Get(x, y).Copy().Opacify(bg));
       out.PrintPixel(code);
     }
-    out.LineFeed();
+    if (y < height - 1)
+      out.LineFeed();
   }
   out.End();
 }
@@ -89,7 +90,8 @@ void PrintImageSixel16(std::ostream& os, const Graphic& graphic) {
       int code = to_index(graphic.Get(x, y).Copy().Opacify(bg));
       out.PrintPixel(code);
     }
-    out.LineFeed();
+    if (y < height - 1)
+      out.LineFeed();
   }
   out.End();
 }
@@ -107,7 +109,8 @@ void PrintImageSixel2(std::ostream& os, const Graphic& graphic) {
       int code = to_index(graphic.Get(x, y).Copy().Opacify(bg));
       out.PrintPixel(code);
     }
-    out.LineFeed();
+    if (y < height - 1)
+      out.LineFeed();
   }
   out.End();
 }
@@ -127,7 +130,8 @@ void PrintImageXterm256(std::ostream& os, const Graphic& graphic) {
       out << FLAGS_space;
     }
     out.Reset();
-    out << "\n";
+    if (y < graphic.height() - 1)
+      out << "\n";
   }
 }
 
@@ -145,7 +149,8 @@ void PrintImageXterm256Unicode(std::ostream& os, const Graphic& graphic) {
       out << kUpperHalfBlock;
     }
     out.Reset();
-    out << "\n";
+    if (y < height - 2)
+      out << "\n";
   }
 }
 
@@ -162,7 +167,8 @@ void PrintImageMacterm(std::ostream& os, const Graphic& graphic) {
       out << color.symbol();
     }
     out.Reset();
-    out << "\n";
+    if (y < height - 2)
+      out << "\n";
   }
 }
 
@@ -179,7 +185,8 @@ void PrintImageNoColor(std::ostream& os, const Graphic& graphic) {
         os << quantizer.Quantize(static_cast<int>(pixel.grey() * 255));
       }
     }
-    cout << "\n";
+    if (y < graphic.height() - 1)
+      cout << "\n";
   }
 }
 

--- a/src/hiptext.cc
+++ b/src/hiptext.cc
@@ -22,6 +22,7 @@
 #include "hiptext/png.h"
 #include "hiptext/macterm.h"
 #include "hiptext/movie.h"
+#include "hiptext/x11.h"
 #include "hiptext/xterm256.h"
 #include "hiptext/termprinter.h"
 #include "hiptext/sixelprinter.h"
@@ -45,10 +46,12 @@ DEFINE_string(bg, "black", "The native background of your terminal specified "
               "you plan copy/pasting the output into something with a white "
               "background like if you were spamming Reddit");
 DEFINE_bool(bgprint, false, "Enable explicit styling when printing characters "
-            "that are nearly identical to the native terminal background");
+              "that are nearly identical to the native terminal background");
 DEFINE_string(space, u8"\u00a0", "The empty character to use when printing. "
               "By default this is a utf8 non-breaking space");
 DEFINE_bool(spectrum, false, "Show color spectrum graph");
+DEFINE_bool(screencast, false, "Screencast desktop. "
+              "Use arrow keys to pan and +/- to zoom.");
 DEFINE_bool(sixel256, false, "Use sixel graphics (256 colors)");
 DEFINE_bool(sixel16, false, "Use sixel graphics (16 colors)");
 DEFINE_bool(sixel2, false, "Use sixel graphics (2 colors)");
@@ -245,6 +248,11 @@ int main(int argc, char** argv) {
   // Did they specify an option that requires no args?
   if (FLAGS_spectrum) {
     artiste.GenerateSpectrum();
+    exit(0);
+  }
+
+  if (FLAGS_screencast) {
+    artiste.PrintX11(X11());
     exit(0);
   }
 

--- a/src/hiptext/artiste.h
+++ b/src/hiptext/artiste.h
@@ -10,6 +10,7 @@
 #include "hiptext/unicode.h"
 
 class Movie;
+class X11;
 class Graphic;
 
 using RenderAlgorithm = std::function<void(std::ostream&, const Graphic&)>;
@@ -24,6 +25,7 @@ class Artiste {  // The one who lives in your terminal.
 
   void PrintImage(Graphic graphic);
   void PrintMovie(Movie movie);
+  void PrintX11(X11 x11);
 
   void GenerateSpectrum();
 
@@ -33,6 +35,7 @@ class Artiste {  // The one who lives in your terminal.
   void ShowCursor();
   void HideCursor();
   void ResetCursor();
+  void ClearScreen();
 
  private:
   void ComputeDimensions(double media_ratio);

--- a/src/hiptext/input.h
+++ b/src/hiptext/input.h
@@ -1,0 +1,24 @@
+#ifndef HIPTEXT_INPUT_H_
+#define HIPTEXT_INPUT_H_
+
+#include <string.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/termios.h>
+
+
+class Input {
+ public:
+  explicit Input();
+  Input(const Input& input);
+
+  void InitializeMain();
+  int KbHit();
+  int GetCh();
+  void Destructor();
+
+ private:
+  struct termios backup;
+};
+
+#endif  // HIPTEXT_INPUT_H_

--- a/src/hiptext/x11.h
+++ b/src/hiptext/x11.h
@@ -1,0 +1,72 @@
+#ifndef HIPTEXT_X11_H_
+#define HIPTEXT_X11_H_
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+#include "hiptext/graphic.h"
+#include "hiptext/input.h"
+
+class X11 {
+ public:
+  explicit X11();
+  X11(X11&& x11);
+  X11(const X11& x11) = delete;
+  void operator=(const X11& x11) = delete;
+
+  Graphic Next();
+
+  inline int width() const { return width_; }
+  inline int height() const { return height_; }
+  inline bool done() const { return done_; }
+
+  // Make C++11 range-based loops work.
+  struct iterator {
+    Graphic operator*() { return x11_->Next(); }
+    const iterator& operator++() { return *this; }
+    bool operator!=(const iterator&) const { return !x11_->done(); }
+    X11* x11_;
+  };
+  iterator begin() { return iterator{this}; }
+  iterator end() { return iterator{this}; }
+
+  void InitializeMain();
+  void TermUpdate(int width, int height);
+  void CreateImage();
+  void DestroyImage();
+  bool HandleInput();
+  void Contain();
+  void Zoom(int);
+  void WaitABit(int);
+
+  double zoom_factor = 3.0 / 2.0;
+
+  int term_width;
+  int term_height;
+  int grab_x = 0;
+  int grab_y = 0;
+  int grab_width;
+  int grab_height;
+  // The number of X pixels representing a TTY 'pixel'
+  int tty_pixel_x_size;
+  int tty_pixel_y_size;
+
+ private:
+  bool IsPointerPixel(int x, int y, int pointer_x, int pointer_y);
+
+  bool done_ = false;  // True when media is complete.
+
+  int width_;  // Desired final size. Defaults to natural context.
+  int height_;
+
+  char *dpyname = ":0";
+  Display *dpy;
+  Screen  *scr;
+  XImage *ximage;
+  unsigned depth = 0;
+
+  Input input;
+  GC gc;
+};
+
+#endif  // HIPTEXT_X11_H_

--- a/src/input.cc
+++ b/src/input.cc
@@ -1,0 +1,41 @@
+
+#include "hiptext/input.h"
+
+Input::Input() {}
+
+void Input::InitializeMain() {
+  struct termios raw;
+
+  tcgetattr(0, &backup);
+  raw = backup;
+
+  // Allow individual keys to be read(), rather than waiting for a newline char
+  raw.c_lflag &= ~ICANON;
+  // Prevent keypresses being echoed to the current cursor position
+  raw.c_lflag &= ~ECHO;
+
+  tcsetattr(0, TCSANOW, &raw);
+}
+
+int Input::KbHit(){
+  struct timeval tv = { 0L, 0L };
+  fd_set fds;
+  FD_ZERO(&fds);
+  FD_SET(0, &fds);
+  return select(1, &fds, NULL, NULL, &tv);
+}
+
+int Input::GetCh(){
+  int r;
+  unsigned char c;
+  if ((r = read(0, &c, sizeof(c))) < 0) {
+    return r;
+  } else {
+    return c;
+  }
+}
+
+void Input::Destructor() {
+  tcsetattr(0, TCSADRAIN, &backup);
+}
+

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -15,6 +15,12 @@ extern "C" {  // ffmpeg hates C++ and won't put this in their headers.
 #include "hiptext/graphic.h"
 #include "hiptext/pixel.h"
 
+#if (LIBAVFORMAT_VERSION_INT) > AV_VERSION_INT(55, 16, 0)
+#define PIX_FMT_RGB24 AV_PIX_FMT_RGB24
+#define avcodec_alloc_frame() av_frame_alloc()
+#define av_free_packet(packet) av_packet_unref(packet)
+#endif
+
 Movie::Movie(const std::string& path) {
   format_ = avformat_alloc_context();
 

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1,0 +1,201 @@
+#include "hiptext/x11.h"
+#include "hiptext/pixel.h"
+#include "hiptext/input.h"
+
+X11::X11() {}
+
+Graphic X11::Next() {
+  unsigned int long pixel;
+  std::vector<Pixel> pixels;
+  int _, pointer_x, pointer_y;
+  unsigned int u_;
+  Window w;
+
+  // Get the coords of the mouse on the desktop
+  XQueryPointer(
+    dpy,
+    RootWindowOfScreen(scr),
+    &w,
+    &w,
+    &pointer_x,
+    &pointer_y,
+    &_, &_, &u_
+  );
+
+  // Get a screengrab of the desktop, or a portion of the desktop
+  XGetSubImage(
+    dpy, RootWindowOfScreen(scr),
+    grab_x, grab_y, grab_width, grab_height,
+    AllPlanes, ZPixmap, ximage, 0, 0
+  );
+
+  for (int y = 0; y < ximage->height; y++) {
+    for (int x = 0; x < ximage->width; x++) {
+      pixel = XGetPixel(ximage, x, y);
+      if (X11::IsPointerPixel(x, y, pointer_x, pointer_y)){
+        pixels.emplace_back(1.0, 1.0, 1.0);
+      } else {
+        pixels.emplace_back(
+          ((pixel >> 16) & 0x0000ff) / 255.0,
+          ((pixel >> 8) & 0x0000ff)  / 255.0,
+          ((pixel) & 0x0000ff)       / 255.0
+        );
+      }
+    }
+  }
+
+  return Graphic(grab_width, grab_height, std::move(pixels));
+}
+
+/*
+ * Overlay the mouse pointer to the size of a single TTY pixel when
+ * mapping pixels to the terminal.
+ */
+bool X11::IsPointerPixel(int x, int y, int pointer_x, int pointer_y) {
+  // Convert x and y from relative to absolute
+  x = grab_x + x;
+  y = grab_y + y;
+  // Multiple tty pixel size by 5 for worse case scenarios when BilinearScale()
+  // can't average the colour such that it displays in the terminal. Ideally this
+  // should be implemented in the various render algorithms.
+  bool within_x_region = ((x - pointer_x) * (x - pointer_x) < tty_pixel_x_size * 5);
+  bool within_y_region = ((y - pointer_y) * (y - pointer_y) < tty_pixel_y_size * 5);
+  return within_x_region && within_y_region;
+}
+
+bool X11::HandleInput() {
+  int k;
+  bool screen_grab_change = false;
+  int pan_shift_x = tty_pixel_x_size * 3;
+  int pan_shift_y = tty_pixel_y_size * 3;
+
+  if (input.KbHit()) {
+    k = input.GetCh();
+    LOG(INFO) << k;
+    switch (k){
+      case 43: // +
+        X11::Zoom(1);
+        break;
+      case 45: // -
+        X11::Zoom(-1);
+        break;
+      case 65: // UP ARROW
+        grab_y = grab_y - pan_shift_y;
+        break;
+      case 66: // DOWN ARROW
+        grab_y = grab_y + pan_shift_y;
+        break;
+      case 68: // LEFT ARROW
+        grab_x = grab_x - pan_shift_x;
+        break;
+      case 67: // RIGHT ARROW
+        grab_x = grab_x + pan_shift_x;
+        break;
+    }
+    screen_grab_change = true;
+    X11::Contain();
+    X11::CreateImage();
+  }
+  return screen_grab_change;
+}
+
+void X11::Zoom(int direction) {
+  int centre_x = grab_x + (grab_width / 2);
+  int centre_y = grab_y + (grab_height / 2);
+  // Zoom in
+  if (direction > 0) {
+    grab_width = grab_width / zoom_factor;
+    grab_height = grab_height / zoom_factor;
+  }
+  // Zoom out
+  if (direction < 0) {
+    grab_width = grab_width * zoom_factor;
+    grab_height = grab_height * zoom_factor;
+  }
+  // Zoom anchored on the centre of the screen
+  grab_x = centre_x - (grab_width / 2);
+  grab_y = centre_y - (grab_height / 2);
+}
+
+void X11::Contain() {
+  if (grab_width > scr->width)
+    grab_width = scr->width;
+  if (grab_height > scr->height)
+    grab_height = scr->height;
+  tty_pixel_x_size = grab_width / term_width;
+  tty_pixel_y_size = grab_height / term_height;
+
+  if (grab_x < 0)
+    grab_x = 0;
+  if (grab_x + grab_width > scr->width)
+    grab_x = scr->width -grab_width;
+  if (grab_y < 0 || (grab_y + grab_height > scr->height))
+    grab_y = 0;
+  if (grab_y + grab_height > scr->height)
+    grab_y = scr->height - grab_height;
+}
+
+void X11::InitializeMain() {
+  if (!(dpy = XOpenDisplay(dpyname))) {
+    perror("Cannot open display");
+    exit(-1);
+  }
+
+  input = Input();
+  input.InitializeMain();
+
+  scr       = DefaultScreenOfDisplay(dpy);
+  depth     = DefaultDepthOfScreen(scr);
+  grab_width  = scr->width;
+  grab_height = scr->height;
+
+  XGCValues gcv;
+  gcv.plane_mask     = AllPlanes;
+  gcv.subwindow_mode = IncludeInferiors;
+  gcv.function       = GXcopy;
+  gcv.foreground     = WhitePixelOfScreen(scr);
+  gcv.background     = BlackPixelOfScreen(scr);
+  gc                 = XCreateGC(dpy, RootWindowOfScreen(scr),
+                                 GCFunction |
+                                 GCPlaneMask |
+                                 GCSubwindowMode |
+                                 GCForeground |
+                                 GCBackground,
+                                 &gcv);
+  X11::CreateImage();
+}
+
+void X11::TermUpdate(int width, int height) {
+  term_width = width;
+  term_height = height;
+  X11::Contain();
+}
+
+
+// Prepare a variable for holding the screengrabs
+void X11::CreateImage() {
+  char *data = (char *)malloc(
+    BitmapUnit(dpy) / 8 * grab_width * grab_height
+  );
+
+  ximage = XCreateImage(
+    dpy,
+    DefaultVisualOfScreen(scr),
+    depth,
+    ZPixmap, 0, data,
+    grab_width, grab_height, 32, 0
+  );
+
+  if (ximage == NULL) {
+    perror("XCreateImage");
+    exit(-1);
+  }
+}
+
+void X11::DestroyImage() {
+  free(ximage->data);
+  ximage->data = NULL;
+  XDestroyImage(ximage);
+  input.Destructor();
+}
+


### PR DESCRIPTION
I don't know if you want this is hiptext? Obviously it's mostly useful for my texttop app. But it's kind of cool anyway I reckon.

It uses X11's API `XGetSubImage` to render the current desktop. Hiptext currently works on Windows right? So it would need a compiler option to disable it on the windows binary.

Also, I'm not 100% sure I've done the colour conversion in [`Graphic Next()`](https://github.com/tombh/hiptext/blob/x11/src/x11.cc#L38) correctly, colours look accurate when rendered, so I assume it's correct. Well in fact this is the first C++ I've written and I don't think I've done the OOP stuff quite right.