### PR TITLE
build: guess flags if `freetype-config` is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ You need clang or gcc >=4.7. You also need to install:
     make -j4
     sudo make install
 
+If you get compile or link errors relating to freetype, and you do not have
+`freetype-config(1)` on your path, try modifying `Makefile` to adjust the
+`LIBFREETYPE_CFLAGS` and `LIBFREETYPE_LIBS` for your system.
+
 ## Usage
 
 ### Images

--- a/configure.ac
+++ b/configure.ac
@@ -47,11 +47,14 @@ AC_SUBST(LIBGFLAGS_CFLAGS)
 AC_SUBST(LIBGFLAGS_LIBS)
 
 AC_CHECK_PROGS(FREETYPE, freetype-config)
-if test -z "$FREETYPE"; then
-  AC_MSG_ERROR([error: libfreetype-dev is required])
+if test -n "$FREETYPE"; then
+  LIBFREETYPE_CFLAGS="`$FREETYPE --cflags`"
+  LIBFREETYPE_LIBS="`$FREETYPE --libs`"
+else
+  AC_MSG_WARN([freetype-config not found; guessing flags])
+  LIBFREETYPE_CFLAGS="-I/usr/include/freetype2"
+  LIBFREETYPE_LIBS="-lfreetype"
 fi
-LIBFREETYPE_CFLAGS="`$FREETYPE --cflags`"
-LIBFREETYPE_LIBS="`$FREETYPE --libs`"
 AC_SUBST(LIBFREETYPE_CFLAGS)
 AC_SUBST(LIBFREETYPE_LIBS)
 


### PR DESCRIPTION
Debian removed the `freetype-config` utility in 2.8.1-1 from 2018:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=870618

This patch falls back if `freetype-config` is not available, using flag
values that work on my Debian-based system.

wchargin-branch: freetype-flags
